### PR TITLE
BUGFIX: Replace deprecated ReactDOM.render with createRoot

### DIFF
--- a/benchmark/src/index.tsx
+++ b/benchmark/src/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import Logger from "@foxglove/log";
 import { initI18n } from "@foxglove/studio-base";
@@ -29,8 +29,8 @@ async function main() {
 
   const { Root } = await import("./Root");
 
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(<Root />, rootEl);
+  const root = createRoot(rootEl!);
+  root.render(<Root />);
 }
 
 void main();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foxbox",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MPL-2.0",
   "private": true,
   "productName": "Foxbox",

--- a/packages/studio-base/src/components/DocumentDropListener.test.tsx
+++ b/packages/studio-base/src/components/DocumentDropListener.test.tsx
@@ -13,7 +13,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { SnackbarProvider } from "notistack";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { act } from "react-dom/test-utils";
 
 import DocumentDropListener from "@foxglove/studio-base/components/DocumentDropListener";
@@ -30,8 +30,9 @@ describe("<DocumentDropListener>", () => {
     wrapper = document.createElement("div");
     document.body.appendChild(wrapper);
 
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.render(
+    const root = createRoot(wrapper!);
+
+    root.render(
       <div>
         <SnackbarProvider>
           <ThemeProvider isDark={false}>
@@ -39,8 +40,8 @@ describe("<DocumentDropListener>", () => {
           </ThemeProvider>
         </SnackbarProvider>
       </div>,
-      wrapper,
     );
+
     (console.error as jest.Mock).mockClear();
   });
 
@@ -61,14 +62,14 @@ describe("<DocumentDropListener>", () => {
     (event as any).dataTransfer = {
       types: ["Files"],
     };
-    act(() => {
-      document.dispatchEvent(event); // The event should NOT bubble up from the document to the window
-    });
+
+    document.dispatchEvent(event); // The event should NOT bubble up from the document to the window
+
     expect(windowDragoverHandler).not.toHaveBeenCalled();
   });
 
   afterEach(() => {
-    document.body.removeChild(wrapper);
+    wrapper.remove();
     window.removeEventListener("dragover", windowDragoverHandler);
   });
 });

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.stories.tsx
@@ -4,7 +4,7 @@
 
 import { StoryObj } from "@storybook/react";
 import { ReactElement, useLayoutEffect, useState } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import { toSec } from "@foxglove/rostime";
 import {
@@ -94,8 +94,8 @@ function SimplePanel({ context }: { context: PanelExtensionContext }) {
 export const SimplePanelRender: StoryObj = {
   render: (): ReactElement => {
     function initPanel(context: PanelExtensionContext) {
-      // eslint-disable-next-line react/no-deprecated
-      ReactDOM.render(<SimplePanel context={context} />, context.panelElement);
+      const root = createRoot(context.panelElement);
+      root.render(<SimplePanel context={context} />);
     }
 
     return (

--- a/packages/studio-base/src/panels/CallService/index.tsx
+++ b/packages/studio-base/src/panels/CallService/index.tsx
@@ -3,32 +3,27 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StrictMode, useMemo } from "react";
-import { createRoot } from "react-dom/client";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
 import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
+import { createSyncRoot } from "@foxglove/studio-base/panels/createSyncRoot";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { CallService } from "./CallService";
 import { Config } from "./types";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
-  const root = createRoot(context.panelElement);
-  root.render(
+  return createSyncRoot(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <CallService context={context} />
       </CaptureErrorBoundary>
     </StrictMode>,
+    context.panelElement,
   );
-  return () => {
-    setTimeout(() => {
-      root.unmount();
-    }, 0);
-  };
 }
 
 type Props = {

--- a/packages/studio-base/src/panels/CallService/index.tsx
+++ b/packages/studio-base/src/panels/CallService/index.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StrictMode, useMemo } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
@@ -16,18 +16,18 @@ import { CallService } from "./CallService";
 import { Config } from "./types";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
+  const root = createRoot(context.panelElement);
+  root.render(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <CallService context={context} />
       </CaptureErrorBoundary>
     </StrictMode>,
-    context.panelElement,
   );
   return () => {
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.unmountComponentAtNode(context.panelElement);
+    setTimeout(() => {
+      root.unmount();
+    }, 0);
   };
 }
 

--- a/packages/studio-base/src/panels/Gauge/index.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.tsx
@@ -3,13 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StrictMode, useMemo } from "react";
-import { createRoot } from "react-dom/client";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
 import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
+import { createSyncRoot } from "@foxglove/studio-base/panels/createSyncRoot";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
@@ -17,8 +17,7 @@ import { Gauge } from "./Gauge";
 import { Config } from "./types";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
-  const root = createRoot(context.panelElement);
-  root.render(
+  return createSyncRoot(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <ThemeProvider isDark>
@@ -26,12 +25,8 @@ function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionCo
         </ThemeProvider>
       </CaptureErrorBoundary>
     </StrictMode>,
+    context.panelElement,
   );
-  return () => {
-    setTimeout(() => {
-      root.unmount();
-    }, 0);
-  };
 }
 
 type Props = {

--- a/packages/studio-base/src/panels/Gauge/index.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StrictMode, useMemo } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
@@ -17,8 +17,8 @@ import { Gauge } from "./Gauge";
 import { Config } from "./types";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
+  const root = createRoot(context.panelElement);
+  root.render(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <ThemeProvider isDark>
@@ -26,11 +26,11 @@ function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionCo
         </ThemeProvider>
       </CaptureErrorBoundary>
     </StrictMode>,
-    context.panelElement,
   );
   return () => {
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.unmountComponentAtNode(context.panelElement);
+    setTimeout(() => {
+      root.unmount();
+    }, 0);
   };
 }
 

--- a/packages/studio-base/src/panels/Indicator/index.tsx
+++ b/packages/studio-base/src/panels/Indicator/index.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StrictMode, useMemo } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
@@ -17,8 +17,8 @@ import { Indicator } from "./Indicator";
 import { Config } from "./types";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
+  const root = createRoot(context.panelElement);
+  root.render(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <ThemeProvider isDark>
@@ -26,11 +26,11 @@ function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionCo
         </ThemeProvider>
       </CaptureErrorBoundary>
     </StrictMode>,
-    context.panelElement,
   );
   return () => {
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.unmountComponentAtNode(context.panelElement);
+    setTimeout(() => {
+      root.unmount();
+    }, 0);
   };
 }
 

--- a/packages/studio-base/src/panels/Indicator/index.tsx
+++ b/packages/studio-base/src/panels/Indicator/index.tsx
@@ -3,13 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StrictMode, useMemo } from "react";
-import { createRoot } from "react-dom/client";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
 import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
+import { createSyncRoot } from "@foxglove/studio-base/panels/createSyncRoot";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
@@ -17,8 +17,7 @@ import { Indicator } from "./Indicator";
 import { Config } from "./types";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
-  const root = createRoot(context.panelElement);
-  root.render(
+  return createSyncRoot(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <ThemeProvider isDark>
@@ -26,12 +25,8 @@ function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionCo
         </ThemeProvider>
       </CaptureErrorBoundary>
     </StrictMode>,
+    context.panelElement,
   );
-  return () => {
-    setTimeout(() => {
-      root.unmount();
-    }, 0);
-  };
 }
 
 type Props = {

--- a/packages/studio-base/src/panels/Map/initPanel.tsx
+++ b/packages/studio-base/src/panels/Map/initPanel.tsx
@@ -34,6 +34,7 @@ export function initPanel(
   crash: ReturnType<typeof useCrash>,
   context: PanelExtensionContext,
 ): () => void {
+  // The lib leaflet changes the DOM somehow that 'createRoot' crashes.
   // eslint-disable-next-line react/no-deprecated
   ReactDOM.render(
     <StrictMode>

--- a/packages/studio-base/src/panels/Map/initPanel.tsx
+++ b/packages/studio-base/src/panels/Map/initPanel.tsx
@@ -7,7 +7,7 @@ import LeafletRetinaIconUrl from "leaflet/dist/images/marker-icon-2x.png";
 import LeafletIconUrl from "leaflet/dist/images/marker-icon.png";
 import LeafletShadowIconUrl from "leaflet/dist/images/marker-shadow.png";
 import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
+import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
@@ -34,17 +34,17 @@ export function initPanel(
   crash: ReturnType<typeof useCrash>,
   context: PanelExtensionContext,
 ): () => void {
-  const root = createRoot(context.panelElement);
-  root.render(
+  // eslint-disable-next-line react/no-deprecated
+  ReactDOM.render(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <MapPanel context={context} />
       </CaptureErrorBoundary>
     </StrictMode>,
+    context.panelElement,
   );
   return () => {
-    setTimeout(() => {
-      root.unmount();
-    }, 0);
+    // eslint-disable-next-line react/no-deprecated
+    ReactDOM.unmountComponentAtNode(context.panelElement);
   };
 }

--- a/packages/studio-base/src/panels/Map/initPanel.tsx
+++ b/packages/studio-base/src/panels/Map/initPanel.tsx
@@ -7,7 +7,7 @@ import LeafletRetinaIconUrl from "leaflet/dist/images/marker-icon-2x.png";
 import LeafletIconUrl from "leaflet/dist/images/marker-icon.png";
 import LeafletShadowIconUrl from "leaflet/dist/images/marker-shadow.png";
 import { StrictMode } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
@@ -34,17 +34,17 @@ export function initPanel(
   crash: ReturnType<typeof useCrash>,
   context: PanelExtensionContext,
 ): () => void {
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
+  const root = createRoot(context.panelElement);
+  root.render(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <MapPanel context={context} />
       </CaptureErrorBoundary>
     </StrictMode>,
-    context.panelElement,
   );
   return () => {
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.unmountComponentAtNode(context.panelElement);
+    setTimeout(() => {
+      root.unmount();
+    }, 0);
   };
 }

--- a/packages/studio-base/src/panels/Map/initPanel.tsx
+++ b/packages/studio-base/src/panels/Map/initPanel.tsx
@@ -6,12 +6,11 @@ import L from "leaflet";
 import LeafletRetinaIconUrl from "leaflet/dist/images/marker-icon-2x.png";
 import LeafletIconUrl from "leaflet/dist/images/marker-icon.png";
 import LeafletShadowIconUrl from "leaflet/dist/images/marker-shadow.png";
-import { StrictMode } from "react";
-import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
 import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
+import { createSyncRoot } from "@foxglove/studio-base/panels/createSyncRoot";
 
 import MapPanel from "./MapPanel";
 
@@ -34,18 +33,10 @@ export function initPanel(
   crash: ReturnType<typeof useCrash>,
   context: PanelExtensionContext,
 ): () => void {
-  // The lib leaflet changes the DOM somehow that 'createRoot' crashes.
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
-    <StrictMode>
-      <CaptureErrorBoundary onError={crash}>
-        <MapPanel context={context} />
-      </CaptureErrorBoundary>
-    </StrictMode>,
+  return createSyncRoot(
+    <CaptureErrorBoundary onError={crash}>
+      <MapPanel context={context} />
+    </CaptureErrorBoundary>,
     context.panelElement,
   );
-  return () => {
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.unmountComponentAtNode(context.panelElement);
-  };
 }

--- a/packages/studio-base/src/panels/Teleop/index.tsx
+++ b/packages/studio-base/src/panels/Teleop/index.tsx
@@ -3,31 +3,26 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StrictMode, useMemo } from "react";
-import { createRoot } from "react-dom/client";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
 import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
+import { createSyncRoot } from "@foxglove/studio-base/panels/createSyncRoot";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import TeleopPanel from "./TeleopPanel";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
-  const root = createRoot(context.panelElement);
-  root.render(
+  return createSyncRoot(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <TeleopPanel context={context} />
       </CaptureErrorBoundary>
     </StrictMode>,
+    context.panelElement,
   );
-  return () => {
-    setTimeout(() => {
-      root.unmount();
-    }, 0);
-  };
 }
 
 type Props = {

--- a/packages/studio-base/src/panels/Teleop/index.tsx
+++ b/packages/studio-base/src/panels/Teleop/index.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StrictMode, useMemo } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
@@ -15,18 +15,18 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import TeleopPanel from "./TeleopPanel";
 
 function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
+  const root = createRoot(context.panelElement);
+  root.render(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <TeleopPanel context={context} />
       </CaptureErrorBoundary>
     </StrictMode>,
-    context.panelElement,
   );
   return () => {
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.unmountComponentAtNode(context.panelElement);
+    setTimeout(() => {
+      root.unmount();
+    }, 0);
   };
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
@@ -20,6 +20,7 @@ import {
 } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { INJECTED_FEATURE_KEYS, useAppContext } from "@foxglove/studio-base/context/AppContext";
 import { TestOptions } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
+import { createSyncRoot } from "@foxglove/studio-base/panels/createSyncRoot";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { SceneExtensionConfig } from "./SceneExtensionConfig";
@@ -36,8 +37,7 @@ type InitPanelArgs = {
 
 function initPanel(args: InitPanelArgs, context: BuiltinPanelExtensionContext) {
   const { crash, forwardedAnalytics, interfaceMode, testOptions, customSceneExtensions } = args;
-  const root = createRoot(context.panelElement);
-  root.render(
+  return createSyncRoot(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <ForwardAnalyticsContextProvider forwardedAnalytics={forwardedAnalytics}>
@@ -50,12 +50,8 @@ function initPanel(args: InitPanelArgs, context: BuiltinPanelExtensionContext) {
         </ForwardAnalyticsContextProvider>
       </CaptureErrorBoundary>
     </StrictMode>,
+    context.panelElement,
   );
-  return () => {
-    setTimeout(() => {
-      root.unmount();
-    }, 0);
-  };
 }
 
 type Props = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StrictMode, useMemo } from "react";
-import { createRoot } from "react-dom/client";
 import { DeepPartial } from "ts-essentials";
 
 import { useCrash } from "@foxglove/hooks";

--- a/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StrictMode, useMemo } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { DeepPartial } from "ts-essentials";
 
 import { useCrash } from "@foxglove/hooks";
@@ -36,8 +36,8 @@ type InitPanelArgs = {
 
 function initPanel(args: InitPanelArgs, context: BuiltinPanelExtensionContext) {
   const { crash, forwardedAnalytics, interfaceMode, testOptions, customSceneExtensions } = args;
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
+  const root = createRoot(context.panelElement);
+  root.render(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
         <ForwardAnalyticsContextProvider forwardedAnalytics={forwardedAnalytics}>
@@ -50,11 +50,11 @@ function initPanel(args: InitPanelArgs, context: BuiltinPanelExtensionContext) {
         </ForwardAnalyticsContextProvider>
       </CaptureErrorBoundary>
     </StrictMode>,
-    context.panelElement,
   );
   return () => {
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.unmountComponentAtNode(context.panelElement);
+    setTimeout(() => {
+      root.unmount();
+    }, 0);
   };
 }
 

--- a/packages/studio-base/src/panels/createSyncRoot.test.tsx
+++ b/packages/studio-base/src/panels/createSyncRoot.test.tsx
@@ -1,0 +1,39 @@
+/** @jest-environment jsdom */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { screen } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+
+import { createSyncRoot } from "@foxglove/studio-base/panels/createSyncRoot";
+
+describe("createSyncRoot", () => {
+  it("should mount the component", async () => {
+    const textTest = "Mount Component Test";
+    const TestComponent = () => <div>{textTest}</div>;
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    act(() => {
+      createSyncRoot(<TestComponent />, container);
+    });
+
+    expect(await screen.findByText(textTest)).toBeDefined();
+  });
+
+  it("should unmount the component", async () => {
+    const textTest = "Unmount Component Test";
+    const TestComponent = () => <div>{textTest}</div>;
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    act(() => {
+      const unmountCb = createSyncRoot(<TestComponent />, container);
+      unmountCb();
+    });
+
+    expect(JSON.stringify(await screen.findByText(textTest))).toBe("{}");
+  });
+});

--- a/packages/studio-base/src/panels/createSyncRoot.tsx
+++ b/packages/studio-base/src/panels/createSyncRoot.tsx
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createRoot } from "react-dom/client";
+
+/**
+ * Creates a synchronized root for rendering React components.
+ *
+ * This function is designed to centralize the creation of React roots
+ * for rendering components within a given HTML element. It addresses
+ * potential race conditions that may occur when mounting and unmounting
+ * components synchronously within the React lifecycle.
+ *
+ * By using a `setTimeout` with a minimal delay of 0 milliseconds, this
+ * function ensures that the rendering and unmounting operations occur
+ * asynchronously, allowing React to complete its current rendering cycle
+ * before proceeding with the next operation. This helps prevent race
+ * conditions and warnings related to synchronously unmounting roots.
+ *
+ * This approach was required since ReactDOM.render() was replaced by createRoot().render.
+ *
+ * @param component The JSX element to be rendered within the root.
+ * @param panelElement The HTML element to serve as the container for the root.
+ * @returns A function to unmount the root when needed.
+ */
+export function createSyncRoot(component: JSX.Element, panelElement: HTMLDivElement): () => void {
+  const root = createRoot(panelElement);
+  setTimeout(() => {
+    root.render(component);
+  }, 0);
+  return () => {
+    setTimeout(() => {
+      root.unmount();
+    }, 0);
+  };
+}

--- a/packages/studio-desktop/src/quicklook/index.tsx
+++ b/packages/studio-desktop/src/quicklook/index.tsx
@@ -5,7 +5,7 @@
 /// <reference types="quicklookjs" />
 
 import { useState, useEffect, useRef } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { useAsync } from "react-use";
 
 import Logger from "@foxglove/log";
@@ -126,12 +126,12 @@ export function main(): void {
     );
   }
 
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
+  const root = createRoot(rootEl);
+
+  root.render(
     <>
       <GlobalStyle />
       <Root />
     </>,
-    rootEl,
   );
 }

--- a/packages/studio-desktop/src/renderer/index.tsx
+++ b/packages/studio-desktop/src/renderer/index.tsx
@@ -6,7 +6,7 @@
 /// <reference types="electron" />
 
 import { StrictMode, useEffect } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import { Sockets } from "@foxglove/electron-socket/renderer";
 import Logger from "@foxglove/log";
@@ -58,8 +58,8 @@ export async function main(params: MainParams): Promise<void> {
   await waitForFonts();
   await initI18n();
 
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
+  const root = createRoot(rootEl);
+  root.render(
     <StrictMode>
       <LogAfterRender>
         <Root
@@ -69,6 +69,5 @@ export async function main(params: MainParams): Promise<void> {
         />
       </LogAfterRender>
     </StrictMode>,
-    rootEl,
   );
 }

--- a/packages/studio-web/src/index.tsx
+++ b/packages/studio-web/src/index.tsx
@@ -93,4 +93,8 @@ export async function main(getParams: () => Promise<MainParams> = async () => ({
       </LogAfterRender>
     </StrictMode>,
   );
+
+  setTimeout(() => {
+    root.unmount();
+  }, 5_000);
 }

--- a/packages/studio-web/src/index.tsx
+++ b/packages/studio-web/src/index.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StrictMode, useEffect } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import Logger from "@foxglove/log";
 import type { IDataSourceFactory } from "@foxglove/studio-base";
@@ -41,6 +41,8 @@ export async function main(getParams: () => Promise<MainParams> = async () => ({
     throw new Error("missing #root element");
   }
 
+  const root = createRoot(rootEl);
+
   const chromeMatch = navigator.userAgent.match(/Chrome\/(\d+)\./);
   const chromeVersion = chromeMatch ? parseInt(chromeMatch[1] ?? "", 10) : 0;
   const isChrome = chromeVersion !== 0;
@@ -55,14 +57,12 @@ export async function main(getParams: () => Promise<MainParams> = async () => ({
   );
 
   if (!canRender) {
-    // eslint-disable-next-line react/no-deprecated
-    ReactDOM.render(
+    root.render(
       <StrictMode>
         <LogAfterRender>
           <CssBaseline>{banner}</CssBaseline>
         </LogAfterRender>
       </StrictMode>,
-      rootEl,
     );
     return;
   }
@@ -85,14 +85,12 @@ export async function main(getParams: () => Promise<MainParams> = async () => ({
     </WebRoot>
   );
 
-  // eslint-disable-next-line react/no-deprecated
-  ReactDOM.render(
+  root.render(
     <StrictMode>
       <LogAfterRender>
         {banner}
         {rootElement}
       </LogAfterRender>
     </StrictMode>,
-    rootEl,
   );
 }

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/studio",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**User-Facing Changes**
Warnings on console about the deprecation of `ReactDOM.render`.

**Description**
This PR addresses warnings appearing on the console by updating occurrences of the deprecated `ReactDOM.render` function to `createRoot`, as necessitated by newer versions of React (>18).

To ensure proper order of mounting and unmounting new roots and to avoid potential race conditions, a workaround utilizing `setTimeout` with a time of 0 was implemented. This workaround synchronizes the mount and unmount operations, aligning with the asynchronous behaviour of `createRoot`.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] I've updated/created the storybook file(s)
- [x] The release version was updated on package.json files