### PR TITLE
[BUGFIX] State Transitions panel is crashing with "RPC Terminated" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foxbox",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MPL-2.0",
   "private": true,
   "productName": "Foxbox",

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -356,9 +356,6 @@ function Chart(props: Props): JSX.Element {
     // closed RPC, causing some panels to become unusable. This approach ignores the error to
     // keep the component functional. Revisit this once the underlying issue is resolved.
     updateChart(newUpdate).catch((err: Error) => {
-      // if (isMounted()) {
-      //   setUpdateError(err);
-      // }
       console.error(err);
     });
   }, [getNewUpdateMessage, isMounted, updateChart]);

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -351,10 +351,15 @@ function Chart(props: Props): JSX.Element {
       return;
     }
 
+    // Temporarily remove setUpdateError to avoid displaying the error caused by re-rendering,
+    // which results in the component crashing. The crash happens because a message is sent to a
+    // closed RPC, causing some panels to become unusable. This approach ignores the error to
+    // keep the component functional. Revisit this once the underlying issue is resolved.
     updateChart(newUpdate).catch((err: Error) => {
-      if (isMounted()) {
-        setUpdateError(err);
-      }
+      // if (isMounted()) {
+      //   setUpdateError(err);
+      // }
+      console.error(err);
     });
   }, [getNewUpdateMessage, isMounted, updateChart]);
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/studio",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**User-Facing Changes**
The default layout of ADP was not functioning correctly. The "State Transitions" panel was crashing due to a re-render problem, causing an RPC to be created and closed twice with the same ID. This led to a message being sent during the process, resulting in the exception "RPC terminated."

**Description**
A complete solution for the problem was not identified, suggesting the issue might stem from a deeper component such as the LayoutManager. Instead of resolving the root cause, the error has been suppressed. A lost message to a closed RPC is not critical since the new RPC operates correctly. However, this issue should be revisited in the future for a more thorough fix.

**Checklist**
- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] I've updated/created the storybook file(s)
- [x] The release version was updated on package.json files
