### PR TITLE
Settings API

### DIFF
--- a/packages/studio-base/src/PanelAPI/useConfigById.ts
+++ b/packages/studio-base/src/PanelAPI/useConfigById.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import * as _ from "lodash-es";
 import { useCallback } from "react";
 import { DeepPartial } from "ts-essentials";
 
@@ -10,6 +11,10 @@ import {
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import {
+  getExtensionPanelSettings,
+  useExtensionCatalog,
+} from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { maybeCast } from "@foxglove/studio-base/util/maybeCast";
 
@@ -21,15 +26,24 @@ export default function useConfigById<Config extends Record<string, unknown>>(
   panelId: string | undefined,
 ): [Config | undefined, SaveConfig<Config>] {
   const { getCurrentLayoutState, savePanelConfigs } = useCurrentLayoutActions();
+  const extensionSettings = useExtensionCatalog(getExtensionPanelSettings);
 
   const configSelector = useCallback(
     (state: DeepPartial<LayoutState>) => {
       if (panelId == undefined) {
         return undefined;
       }
-      return maybeCast<Config>(state.selectedLayout?.data?.configById?.[panelId]);
+      const stateConfig = maybeCast<Config>(state.selectedLayout?.data?.configById?.[panelId]);
+      const topics = Object.keys(stateConfig?.topics ?? {});
+      const topicsSettings = _.merge(
+        {},
+        ...topics.map((topic) => ({ [topic]: extensionSettings[topic]?.defaultConfig })),
+        stateConfig?.topics,
+      );
+
+      return maybeCast<Config>({ ...stateConfig, topics: topicsSettings });
     },
-    [panelId],
+    [panelId, extensionSettings],
   );
 
   const config = useCurrentLayoutSelector(configSelector);

--- a/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
@@ -55,6 +55,7 @@ export function convertMessage(
       message: convertedMessage,
       originalMessageEvent: messageEvent,
       sizeInBytes: messageEvent.sizeInBytes,
+      topicConfig: messageEvent.topicConfig,
     });
   }
 }

--- a/packages/studio-base/src/context/ExtensionCatalogContext.ts
+++ b/packages/studio-base/src/context/ExtensionCatalogContext.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import * as _ from "lodash-es";
 import { createContext } from "react";
 import { StoreApi, useStore } from "zustand";
 
@@ -9,6 +10,7 @@ import { useGuaranteedContext } from "@foxglove/hooks";
 import {
   ExtensionPanelRegistration,
   Immutable,
+  PanelSettings,
   RegisterMessageConverterArgs,
 } from "@foxglove/studio";
 import { TopicAliasFunctions } from "@foxglove/studio-base/players/TopicAliasingPlayer/TopicAliasingPlayer";
@@ -42,4 +44,13 @@ export const ExtensionCatalogContext = createContext<undefined | StoreApi<Extens
 export function useExtensionCatalog<T>(selector: (registry: ExtensionCatalog) => T): T {
   const context = useGuaranteedContext(ExtensionCatalogContext);
   return useStore(context, selector);
+}
+
+export function getExtensionPanelSettings(
+  reg: ExtensionCatalog,
+): Record<string, Record<string, PanelSettings<unknown>>> {
+  return _.merge(
+    {},
+    ...(reg.installedMessageConverters ?? []).map((converter) => converter.panelSettings),
+  );
 }

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -125,6 +125,8 @@ export type MessageEvent<T = unknown> = {
    * un-converted message event.
    */
   originalMessageEvent?: MessageEvent;
+
+  topicConfig?: unknown;
 };
 
 export interface LayoutActions {
@@ -411,10 +413,17 @@ export type ExtensionPanelRegistration = {
   initPanel: (context: PanelExtensionContext) => void | (() => void);
 };
 
+export interface PanelSettings<ExtensionSettings> {
+  settings: (config?: ExtensionSettings) => SettingsTreeNode;
+  handler: (action: SettingsTreeAction, config?: ExtensionSettings) => void;
+  defaultConfig?: ExtensionSettings;
+}
+
 export type RegisterMessageConverterArgs<Src> = {
   fromSchemaName: string;
   toSchemaName: string;
   converter: (msg: Src, event: Immutable<MessageEvent<Src>>) => unknown;
+  panelSettings?: Record<string, Record<string, PanelSettings<unknown>>>;
 };
 
 type BaseTopic = { name: string; schemaName?: string };


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
Allow the user to link settings to message converters depending on the panel type and the topic name.
Here's an [extension](https://github.com/user-attachments/files/16049509/ExtensionSettingsAPI.zip) to test that functionality: it basically adds a setting for the em/drivingtube/polyline topic in the 3D panel to change the shape of the displayed dots from cubes to spheres



<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [ ] The web version was tested and it is running ok
- [ ] The desktop version was tested and it is running ok
- [ ] I've updated/created the storybook file(s)
- [ ] The release version was updated on package.json files
