### PR TITLE
Fix: Add github secret in order to enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       # We found daily updates to be too noisy. They consumed too much CI time and engineer review
       # time relative to the benefit of being on such a bleeding edge.
       interval: monthly
-    open-pull-requests-limit: 25
+    open-pull-requests-limit: 5
     labels: [] # disable default labels
 
     # Define groups of dependencies to be updated together

--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -10,7 +10,7 @@
 name: Dependabot
 
 on:
-  - pull_request_target
+  - workflow_dispatch
 
 jobs:
   fix:

--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -30,7 +30,7 @@ jobs:
           # Using a Personal Access Token here is required to trigger workflows on our new commit.
           # The default GitHub token doesn't trigger any workflows.
           # See: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854/2
-          token: ${{ secrets.FOXGLOVEBOT_GITHUB_TOKEN }}
+          token: ${{ secrets.LITCHBLICK_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
 
       - run: git lfs pull --include .yarn/
@@ -61,7 +61,7 @@ jobs:
       - uses: octokit/request-action@v2.1.9
         if: contains(fromJSON('["opened", "reopened"]'), github.event.action)
         env:
-          GITHUB_TOKEN: ${{ secrets.FOXGLOVEBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LITCHBLICK_GITHUB_TOKEN }}
         with:
           route: POST /repos/{owner_and_repo}/pulls/{pull_number}/reviews
           owner_and_repo: ${{ github.repository }}
@@ -71,7 +71,7 @@ jobs:
       - uses: octokit/request-action@v2.1.9
         if: contains(fromJSON('["opened", "reopened"]'), github.event.action)
         env:
-          GITHUB_TOKEN: ${{ secrets.FOXGLOVEBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LITCHBLICK_GITHUB_TOKEN }}
         with:
           route: POST /repos/{owner_and_repo}/issues/{pull_number}/comments
           owner_and_repo: ${{ github.repository }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -41,7 +41,7 @@ jobs:
           base: main
           head: release/${{ github.event.release.tag_name }}
         env:
-          GITHUB_TOKEN: ${{ secrets.FOXGLOVEBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LITCHBLICK_GITHUB_TOKEN }}
 
   npm:
     name: Publish to NPM

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ To create a branch in this repository, please follow the guidelines below, ensur
 - `test` : This is intended for experimental changes, where the main goal is to explore new ideas or test solutions without addressing a specific issue.
 - `docs` : Designate this branch for updates and improvements to documentation, ensuring that information is current and helpful to users.
 - `wip` (Work In Progress): Use this for ongoing development that is not yet ready for merging into the main branch.
+- `cicd` : Use this for changes into pipeline ci/cd scripts
 
 ### Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foxbox",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "MPL-2.0",
   "private": true,
   "productName": "Foxbox",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/studio",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**User-Facing Changes**
There are no user facing changes

**Description**
We are changing the github secret in order to enable dependabot to run into the pipeline. I've also included a new branch type called cicd to include cases like this pull request. We are also changing the number of pull requests openned by the bot and the run strategy manual in order to be able to address the needed changes. 

Docs:
-  https://docs.github.com/en/code-security/dependabot
- https://docs.github.com/en/code-security/dependabot

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] The release version was updated on package.json files
