### PR TITLE
Fix: Changing workflow order for dependabot

### DIFF
--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -32,12 +32,11 @@ jobs:
           # See: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854/2
           token: ${{ secrets.LITCHBLICK_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
+          lfs: true
 
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: 16.17
-
-      - run: git lfs pull --include .yarn/
 
       - run: corepack enable
 

--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -33,14 +33,13 @@ jobs:
           token: ${{ secrets.LITCHBLICK_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - run: git lfs pull --include .yarn/
-
-      - run: corepack enable
-
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: 16.17
-          cache: yarn
+
+      - run: git lfs pull --include .yarn/
+
+      - run: corepack enable
 
       - run: yarn install --mode skip-build
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foxbox",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "license": "MPL-2.0",
   "private": true,
   "productName": "Foxbox",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/studio",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
Everytime that some dependabot PR was oppened the following error was preventing the dependabot step to run:
`Error when performing the request to https://registry.npmjs.org/yarn/latest; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting
3414    at fetch (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22762:11)`

We changed the dependabot-fix script  to avoid problems when trying to run corepack enable command.

Main changes:
- Changing the script order to avoid error when running corepack enable command
- Adding 'lfs:true' and removing the manual command  'git lfs pull --include .yarn/'

**Relevant links**
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
- https://github.com/foxglove/studio/actions/runs/8118725898/job/22193503028
- https://github.com/actions/checkout/issues/270

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] I've updated/created the storybook file(s)
- [x] The release version was updated on package.json files
