### PR TITLE
support msg.stamp as an alternative to msg.header.stamp

### DIFF
--- a/packages/studio-base/src/util/time.ts
+++ b/packages/studio-base/src/util/time.ts
@@ -60,6 +60,12 @@ export function getTimestampForMessage(message: unknown): Time | undefined {
     if (stamp != undefined && typeof stamp === "object" && "sec" in stamp && "nsec" in stamp) {
       return stamp;
     }
+  } else if (Object.hasOwn(message as Object, "stamp")) {
+    // Some messages use .stamp directly, instead of .header.stamp
+    const stamp = (message as Partial<{stamp : Time}>).stamp;
+    if (stamp != undefined && typeof stamp === "object" && "sec" in stamp && "nsec" in stamp) {
+      return stamp;
+    }
   }
 
   return undefined;


### PR DESCRIPTION
**User-Facing Changes**
Support plotting with (msg).stamp in addition to (msg).header.stamp, for messages that don't wrap their timestamp in a `std_msgs/Header`. A similar workaround exists for `MarkerArray`.

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [ ] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] I've updated/created the storybook file(s)
- [ ] The release version was updated on package.json files
